### PR TITLE
Support for self detecting memory leaks in Turbo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Turbo is a no fluff, no huff node.js Test Runner. Its guiding principles are as 
 
 * can exclude specific files with the '--exclude' flag
 
+* can self detect memory leaks with the '--leaks' flag
+
 
 Install
 -------
@@ -66,6 +68,8 @@ Available options:
 --test=<test>                   run single test function in a file (only works when one test file used)
 --timeout=<seconds>             timeout value for each test function (60 seconds by default)
 --exclude=<file1,file2>         exclude specific test files
+--leaks=<true|false>            attempt to self detect memory leaks
+
 ```
 
 Examples
@@ -129,3 +133,11 @@ var assert = require('chai').assert;
 assert.lengthOf(foo, 3, "Foo's value has a length of 3")
 ```
 
+Memory Leaks
+------------
+
+Turbo can attempt to detect memory leaks, when enabled with the `--leaks` flag, this works as follows:
+
+* Turbo uses [Memwatch](https://www.npmjs.com/package/memwatch) to detect leak events
+* When a leak event happens, Turbo uses [heapdump](https://github.com/bnoordhuis/node-heapdump) to take a shapshot of the V8 heap and dump it to disk.
+* These snapshots can then be inspected using Chrome's DevTools Profiler - a great tool for tracking down memory leaks.

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.4.1",
   "description": "Turbo the node.js Test Runner",
   "main": "turbo.js",
-  "bin" : {
+  "bin": {
     "turbo": "./turbo.js"
   },
   "scripts": {
     "test": "make test"
+  },
+  "engines": {
+    "node": "0.10.x"
   },
   "repository": "",
   "keywords": [
@@ -19,14 +22,16 @@
   "author": "Damian Beresford",
   "license": "MIT",
   "dependencies": {
-    "async": "~0.2.9",
-    "rc": "~0.3.1",
-    "underscore": "~1.5.2",
-    "bunyan": "0.22.0"
+    "async": "0.2.9",
+    "bunyan": "0.22.0",
+    "heapdump": "0.3.5",
+    "memwatch": "0.2.2",
+    "rc": "0.3.1",
+    "underscore": "1.5.2"
   },
-  "devDependencies":{
-    "proxyquire":"0.4.1",
+  "devDependencies": {
+    "proxyquire": "0.4.1",
     "istanbul": "0.1.42"
-  },  
+  },
   "global": true
 }

--- a/test/testfiles/leak.js
+++ b/test/testfiles/leak.js
@@ -1,0 +1,27 @@
+var bar = [];
+
+function Foo() {
+  this.hello = 'world';
+}
+
+exports.leakTest = function(finish) {
+  var count = 0;
+
+  function leak() {
+    for (var i=0; i<10000; i++) {
+      bar.push(new Foo());
+    }
+    count += 1;
+    if (count < 10000) {
+      setTimeout(function() {
+        leak();
+      },2);
+    } else {
+      finish();
+    }
+  }
+
+  setTimeout(function() {
+    leak();
+  }, 500);
+}


### PR DESCRIPTION
Note: couldn't come up with a good automated test, but to test manually, `./turbo.js
test/testfiles/leak.js` should generate some heapdumps.
